### PR TITLE
Refactor: community configurations namespaced

### DIFF
--- a/config/crd/bases/edgeautoscaler.polimi.it_communityconfigurations.yaml
+++ b/config/crd/bases/edgeautoscaler.polimi.it_communityconfigurations.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: CommunityConfigurationList
     plural: communityconfigurations
     singular: communityconfiguration
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:

--- a/pkg/apis/edgeautoscaler/v1alpha1/types.go
+++ b/pkg/apis/edgeautoscaler/v1alpha1/types.go
@@ -17,9 +17,7 @@ type CommunityConfigurationList struct {
 
 // CommunityConfiguration is a configuration for the autoscaling system.
 // +genclient
-// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster
 type CommunityConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/generated/clientset/versioned/typed/edgeautoscaler/v1alpha1/communityconfiguration.go
+++ b/pkg/generated/clientset/versioned/typed/edgeautoscaler/v1alpha1/communityconfiguration.go
@@ -17,7 +17,7 @@ import (
 // CommunityConfigurationsGetter has a method to return a CommunityConfigurationInterface.
 // A group's client should implement this interface.
 type CommunityConfigurationsGetter interface {
-	CommunityConfigurations() CommunityConfigurationInterface
+	CommunityConfigurations(namespace string) CommunityConfigurationInterface
 }
 
 // CommunityConfigurationInterface has methods to work with CommunityConfiguration resources.
@@ -36,12 +36,14 @@ type CommunityConfigurationInterface interface {
 // communityConfigurations implements CommunityConfigurationInterface
 type communityConfigurations struct {
 	client rest.Interface
+	ns     string
 }
 
 // newCommunityConfigurations returns a CommunityConfigurations
-func newCommunityConfigurations(c *EdgeautoscalerV1alpha1Client) *communityConfigurations {
+func newCommunityConfigurations(c *EdgeautoscalerV1alpha1Client, namespace string) *communityConfigurations {
 	return &communityConfigurations{
 		client: c.RESTClient(),
+		ns:     namespace,
 	}
 }
 
@@ -49,6 +51,7 @@ func newCommunityConfigurations(c *EdgeautoscalerV1alpha1Client) *communityConfi
 func (c *communityConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CommunityConfiguration, err error) {
 	result = &v1alpha1.CommunityConfiguration{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("communityconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -65,6 +68,7 @@ func (c *communityConfigurations) List(ctx context.Context, opts v1.ListOptions)
 	}
 	result = &v1alpha1.CommunityConfigurationList{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("communityconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -81,6 +85,7 @@ func (c *communityConfigurations) Watch(ctx context.Context, opts v1.ListOptions
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Namespace(c.ns).
 		Resource("communityconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -91,6 +96,7 @@ func (c *communityConfigurations) Watch(ctx context.Context, opts v1.ListOptions
 func (c *communityConfigurations) Create(ctx context.Context, communityConfiguration *v1alpha1.CommunityConfiguration, opts v1.CreateOptions) (result *v1alpha1.CommunityConfiguration, err error) {
 	result = &v1alpha1.CommunityConfiguration{}
 	err = c.client.Post().
+		Namespace(c.ns).
 		Resource("communityconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(communityConfiguration).
@@ -103,6 +109,7 @@ func (c *communityConfigurations) Create(ctx context.Context, communityConfigura
 func (c *communityConfigurations) Update(ctx context.Context, communityConfiguration *v1alpha1.CommunityConfiguration, opts v1.UpdateOptions) (result *v1alpha1.CommunityConfiguration, err error) {
 	result = &v1alpha1.CommunityConfiguration{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("communityconfigurations").
 		Name(communityConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -115,6 +122,7 @@ func (c *communityConfigurations) Update(ctx context.Context, communityConfigura
 // Delete takes name of the communityConfiguration and deletes it. Returns an error if one occurs.
 func (c *communityConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("communityconfigurations").
 		Name(name).
 		Body(&opts).
@@ -129,6 +137,7 @@ func (c *communityConfigurations) DeleteCollection(ctx context.Context, opts v1.
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("communityconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -141,6 +150,7 @@ func (c *communityConfigurations) DeleteCollection(ctx context.Context, opts v1.
 func (c *communityConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CommunityConfiguration, err error) {
 	result = &v1alpha1.CommunityConfiguration{}
 	err = c.client.Patch(pt).
+		Namespace(c.ns).
 		Resource("communityconfigurations").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/generated/clientset/versioned/typed/edgeautoscaler/v1alpha1/edgeautoscaler_client.go
+++ b/pkg/generated/clientset/versioned/typed/edgeautoscaler/v1alpha1/edgeautoscaler_client.go
@@ -19,8 +19,8 @@ type EdgeautoscalerV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *EdgeautoscalerV1alpha1Client) CommunityConfigurations() CommunityConfigurationInterface {
-	return newCommunityConfigurations(c)
+func (c *EdgeautoscalerV1alpha1Client) CommunityConfigurations(namespace string) CommunityConfigurationInterface {
+	return newCommunityConfigurations(c, namespace)
 }
 
 func (c *EdgeautoscalerV1alpha1Client) CommunitySchedules(namespace string) CommunityScheduleInterface {

--- a/pkg/generated/clientset/versioned/typed/edgeautoscaler/v1alpha1/fake/fake_communityconfiguration.go
+++ b/pkg/generated/clientset/versioned/typed/edgeautoscaler/v1alpha1/fake/fake_communityconfiguration.go
@@ -17,6 +17,7 @@ import (
 // FakeCommunityConfigurations implements CommunityConfigurationInterface
 type FakeCommunityConfigurations struct {
 	Fake *FakeEdgeautoscalerV1alpha1
+	ns   string
 }
 
 var communityconfigurationsResource = schema.GroupVersionResource{Group: "edgeautoscaler.polimi.it", Version: "v1alpha1", Resource: "communityconfigurations"}
@@ -26,7 +27,8 @@ var communityconfigurationsKind = schema.GroupVersionKind{Group: "edgeautoscaler
 // Get takes name of the communityConfiguration, and returns the corresponding communityConfiguration object, and an error if there is any.
 func (c *FakeCommunityConfigurations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CommunityConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(communityconfigurationsResource, name), &v1alpha1.CommunityConfiguration{})
+		Invokes(testing.NewGetAction(communityconfigurationsResource, c.ns, name), &v1alpha1.CommunityConfiguration{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -36,7 +38,8 @@ func (c *FakeCommunityConfigurations) Get(ctx context.Context, name string, opti
 // List takes label and field selectors, and returns the list of CommunityConfigurations that match those selectors.
 func (c *FakeCommunityConfigurations) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.CommunityConfigurationList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(communityconfigurationsResource, communityconfigurationsKind, opts), &v1alpha1.CommunityConfigurationList{})
+		Invokes(testing.NewListAction(communityconfigurationsResource, communityconfigurationsKind, c.ns, opts), &v1alpha1.CommunityConfigurationList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -57,13 +60,15 @@ func (c *FakeCommunityConfigurations) List(ctx context.Context, opts v1.ListOpti
 // Watch returns a watch.Interface that watches the requested communityConfigurations.
 func (c *FakeCommunityConfigurations) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(communityconfigurationsResource, opts))
+		InvokesWatch(testing.NewWatchAction(communityconfigurationsResource, c.ns, opts))
+
 }
 
 // Create takes the representation of a communityConfiguration and creates it.  Returns the server's representation of the communityConfiguration, and an error, if there is any.
 func (c *FakeCommunityConfigurations) Create(ctx context.Context, communityConfiguration *v1alpha1.CommunityConfiguration, opts v1.CreateOptions) (result *v1alpha1.CommunityConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(communityconfigurationsResource, communityConfiguration), &v1alpha1.CommunityConfiguration{})
+		Invokes(testing.NewCreateAction(communityconfigurationsResource, c.ns, communityConfiguration), &v1alpha1.CommunityConfiguration{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -73,7 +78,8 @@ func (c *FakeCommunityConfigurations) Create(ctx context.Context, communityConfi
 // Update takes the representation of a communityConfiguration and updates it. Returns the server's representation of the communityConfiguration, and an error, if there is any.
 func (c *FakeCommunityConfigurations) Update(ctx context.Context, communityConfiguration *v1alpha1.CommunityConfiguration, opts v1.UpdateOptions) (result *v1alpha1.CommunityConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(communityconfigurationsResource, communityConfiguration), &v1alpha1.CommunityConfiguration{})
+		Invokes(testing.NewUpdateAction(communityconfigurationsResource, c.ns, communityConfiguration), &v1alpha1.CommunityConfiguration{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -83,13 +89,14 @@ func (c *FakeCommunityConfigurations) Update(ctx context.Context, communityConfi
 // Delete takes name of the communityConfiguration and deletes it. Returns an error if one occurs.
 func (c *FakeCommunityConfigurations) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(communityconfigurationsResource, name), &v1alpha1.CommunityConfiguration{})
+		Invokes(testing.NewDeleteAction(communityconfigurationsResource, c.ns, name), &v1alpha1.CommunityConfiguration{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCommunityConfigurations) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(communityconfigurationsResource, listOpts)
+	action := testing.NewDeleteCollectionAction(communityconfigurationsResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.CommunityConfigurationList{})
 	return err
@@ -98,7 +105,8 @@ func (c *FakeCommunityConfigurations) DeleteCollection(ctx context.Context, opts
 // Patch applies the patch and returns the patched communityConfiguration.
 func (c *FakeCommunityConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CommunityConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(communityconfigurationsResource, name, pt, data, subresources...), &v1alpha1.CommunityConfiguration{})
+		Invokes(testing.NewPatchSubresourceAction(communityconfigurationsResource, c.ns, name, pt, data, subresources...), &v1alpha1.CommunityConfiguration{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/generated/clientset/versioned/typed/edgeautoscaler/v1alpha1/fake/fake_edgeautoscaler_client.go
+++ b/pkg/generated/clientset/versioned/typed/edgeautoscaler/v1alpha1/fake/fake_edgeautoscaler_client.go
@@ -12,8 +12,8 @@ type FakeEdgeautoscalerV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeEdgeautoscalerV1alpha1) CommunityConfigurations() v1alpha1.CommunityConfigurationInterface {
-	return &FakeCommunityConfigurations{c}
+func (c *FakeEdgeautoscalerV1alpha1) CommunityConfigurations(namespace string) v1alpha1.CommunityConfigurationInterface {
+	return &FakeCommunityConfigurations{c, namespace}
 }
 
 func (c *FakeEdgeautoscalerV1alpha1) CommunitySchedules(namespace string) v1alpha1.CommunityScheduleInterface {

--- a/pkg/generated/informers/externalversions/edgeautoscaler/v1alpha1/communityconfiguration.go
+++ b/pkg/generated/informers/externalversions/edgeautoscaler/v1alpha1/communityconfiguration.go
@@ -26,32 +26,33 @@ type CommunityConfigurationInformer interface {
 type communityConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	namespace        string
 }
 
 // NewCommunityConfigurationInformer constructs a new informer for CommunityConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCommunityConfigurationInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCommunityConfigurationInformer(client, resyncPeriod, indexers, nil)
+func NewCommunityConfigurationInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCommunityConfigurationInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCommunityConfigurationInformer constructs a new informer for CommunityConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCommunityConfigurationInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCommunityConfigurationInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.EdgeautoscalerV1alpha1().CommunityConfigurations().List(context.TODO(), options)
+				return client.EdgeautoscalerV1alpha1().CommunityConfigurations(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.EdgeautoscalerV1alpha1().CommunityConfigurations().Watch(context.TODO(), options)
+				return client.EdgeautoscalerV1alpha1().CommunityConfigurations(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&edgeautoscalerv1alpha1.CommunityConfiguration{},
@@ -61,7 +62,7 @@ func NewFilteredCommunityConfigurationInformer(client versioned.Interface, resyn
 }
 
 func (f *communityConfigurationInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCommunityConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCommunityConfigurationInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *communityConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/generated/informers/externalversions/edgeautoscaler/v1alpha1/interface.go
+++ b/pkg/generated/informers/externalversions/edgeautoscaler/v1alpha1/interface.go
@@ -27,7 +27,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // CommunityConfigurations returns a CommunityConfigurationInformer.
 func (v *version) CommunityConfigurations() CommunityConfigurationInformer {
-	return &communityConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &communityConfigurationInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // CommunitySchedules returns a CommunityScheduleInformer.

--- a/pkg/generated/listers/edgeautoscaler/v1alpha1/communityconfiguration.go
+++ b/pkg/generated/listers/edgeautoscaler/v1alpha1/communityconfiguration.go
@@ -15,9 +15,8 @@ type CommunityConfigurationLister interface {
 	// List lists all CommunityConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.CommunityConfiguration, err error)
-	// Get retrieves the CommunityConfiguration from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.CommunityConfiguration, error)
+	// CommunityConfigurations returns an object that can list and get CommunityConfigurations.
+	CommunityConfigurations(namespace string) CommunityConfigurationNamespaceLister
 	CommunityConfigurationListerExpansion
 }
 
@@ -39,9 +38,41 @@ func (s *communityConfigurationLister) List(selector labels.Selector) (ret []*v1
 	return ret, err
 }
 
-// Get retrieves the CommunityConfiguration from the index for a given name.
-func (s *communityConfigurationLister) Get(name string) (*v1alpha1.CommunityConfiguration, error) {
-	obj, exists, err := s.indexer.GetByKey(name)
+// CommunityConfigurations returns an object that can list and get CommunityConfigurations.
+func (s *communityConfigurationLister) CommunityConfigurations(namespace string) CommunityConfigurationNamespaceLister {
+	return communityConfigurationNamespaceLister{indexer: s.indexer, namespace: namespace}
+}
+
+// CommunityConfigurationNamespaceLister helps list and get CommunityConfigurations.
+// All objects returned here must be treated as read-only.
+type CommunityConfigurationNamespaceLister interface {
+	// List lists all CommunityConfigurations in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
+	List(selector labels.Selector) (ret []*v1alpha1.CommunityConfiguration, err error)
+	// Get retrieves the CommunityConfiguration from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.CommunityConfiguration, error)
+	CommunityConfigurationNamespaceListerExpansion
+}
+
+// communityConfigurationNamespaceLister implements the CommunityConfigurationNamespaceLister
+// interface.
+type communityConfigurationNamespaceLister struct {
+	indexer   cache.Indexer
+	namespace string
+}
+
+// List lists all CommunityConfigurations in the indexer for a given namespace.
+func (s communityConfigurationNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.CommunityConfiguration, err error) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.CommunityConfiguration))
+	})
+	return ret, err
+}
+
+// Get retrieves the CommunityConfiguration from the indexer for a given namespace and name.
+func (s communityConfigurationNamespaceLister) Get(name string) (*v1alpha1.CommunityConfiguration, error) {
+	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generated/listers/edgeautoscaler/v1alpha1/expansion_generated.go
+++ b/pkg/generated/listers/edgeautoscaler/v1alpha1/expansion_generated.go
@@ -6,6 +6,10 @@ package v1alpha1
 // CommunityConfigurationLister.
 type CommunityConfigurationListerExpansion interface{}
 
+// CommunityConfigurationNamespaceListerExpansion allows custom methods to be added to
+// CommunityConfigurationNamespaceLister.
+type CommunityConfigurationNamespaceListerExpansion interface{}
+
 // CommunityScheduleListerExpansion allows custom methods to be added to
 // CommunityScheduleLister.
 type CommunityScheduleListerExpansion interface{}

--- a/pkg/system-controller/main.go
+++ b/pkg/system-controller/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"time"
 
-	clientset "github.com/lterrac/edge-autoscaler/pkg/generated/clientset/versioned"
+	eaclientset "github.com/lterrac/edge-autoscaler/pkg/generated/clientset/versioned"
 	eainformers "github.com/lterrac/edge-autoscaler/pkg/generated/informers/externalversions"
 	informers2 "github.com/lterrac/edge-autoscaler/pkg/informers"
 	"github.com/lterrac/edge-autoscaler/pkg/signals"
@@ -33,7 +33,7 @@ func main() {
 		klog.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
-	eaclient, err := clientset.NewForConfig(cfg)
+	eaclient, err := eaclientset.NewForConfig(cfg)
 	if err != nil {
 		klog.Fatalf("Error building example clientset: %s", err.Error())
 	}

--- a/pkg/system-controller/pkg/controller/sync.go
+++ b/pkg/system-controller/pkg/controller/sync.go
@@ -22,7 +22,7 @@ const (
 
 func (c *SystemController) syncCommunityConfiguration(key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
-	_, name, err := cache.SplitMetaNamespaceKey(key)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
@@ -30,7 +30,7 @@ func (c *SystemController) syncCommunityConfiguration(key string) error {
 	}
 
 	// Get the CC resource with this namespace/name
-	cc, err := c.listers.CommunityConfigurationLister.Get(name)
+	cc, err := c.listers.CommunityConfigurationLister.CommunityConfigurations(namespace).Get(name)
 
 	//TODO: handle multiple Community Settings in cluster. Now there should be ONLY one configuration per cluster
 	if err != nil {


### PR DESCRIPTION
This PR changes the scope of `Community Configurations` CRD from `Cluster` to `Namespaced`