### PR TITLE
fix: remove role label

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -10,11 +10,6 @@ type Community string
 type CommunityInstances string
 
 const (
-	Leader CommunityRole = "LEADER"
-	Member CommunityRole = "MEMBER"
-	// CommunityRoleLabel identifies a role of a node inside a community
-	CommunityRoleLabel CommunityRole = "edgeautoscaler.polimi.it/role"
-
 	// CommunityLabel defines the community a node belongs to
 	CommunityLabel Community = "edgeautoscaler.polimi.it/community"
 

--- a/pkg/system-controller/pkg/controller/sync.go
+++ b/pkg/system-controller/pkg/controller/sync.go
@@ -59,13 +59,10 @@ func (c *SystemController) syncCommunityConfiguration(key string) error {
 		return fmt.Errorf("error while executing SLPA: %s", err)
 	}
 
-	//add the namespace to community labels
+	//add the community label with the corresponding namespace
 	for _, community := range communities {
 		for _, member := range community.Members {
-			member.Labels[ealabels.CommunityLabel.WithNamespace(cc.Namespace).String()] = member.Labels[ealabels.CommunityLabel.String()]
-			member.Labels[ealabels.CommunityRoleLabel.WithNamespace(cc.Namespace).String()] = member.Labels[ealabels.CommunityRoleLabel.String()]
-			delete(member.Labels, ealabels.CommunityLabel.String())
-			delete(member.Labels, ealabels.CommunityRoleLabel.String())
+			member.Labels[ealabels.CommunityLabel.WithNamespace(cc.Namespace).String()] = community.Name
 		}
 	}
 

--- a/pkg/system-controller/pkg/controller/update-communities.go
+++ b/pkg/system-controller/pkg/controller/update-communities.go
@@ -91,10 +91,6 @@ func (c *CommunityUpdater) UpdateCommunityNodes(namespace string, communities []
 				labels[ealabels.CommunityLabel.WithNamespace(namespace).String()] = community.Name
 			}
 
-			if role, ok := labels[ealabels.CommunityRoleLabel.WithNamespace(namespace).String()]; !ok || role != member.Labels[ealabels.CommunityRoleLabel.WithNamespace(namespace).String()] {
-				labels[ealabels.CommunityRoleLabel.WithNamespace(namespace).String()] = member.Labels[ealabels.CommunityRoleLabel.WithNamespace(namespace).String()].(string)
-			}
-
 			_, err := c.updateNode(context.TODO(), node, v1.UpdateOptions{})
 
 			if err != nil {
@@ -118,12 +114,6 @@ func (c *CommunityUpdater) UpdateCommunityNodes(namespace string, communities []
 		}
 
 		delete(labels, ealabels.CommunityLabel.WithNamespace(namespace).String())
-
-		if _, ok := labels[ealabels.CommunityRoleLabel.WithNamespace(namespace).String()]; !ok {
-			continue
-		}
-
-		delete(labels, ealabels.CommunityRoleLabel.WithNamespace(namespace).String())
 
 		_, err := c.updateNode(context.TODO(), node, v1.UpdateOptions{})
 
@@ -149,10 +139,6 @@ func (c *CommunityUpdater) ClearNodesLabels(namespace string) error {
 	for _, node := range clusterNodes {
 		if _, ok := node.Labels[ealabels.CommunityLabel.WithNamespace(namespace).String()]; ok {
 			delete(node.Labels, ealabels.CommunityLabel.WithNamespace(namespace).String())
-		}
-
-		if _, ok := node.Labels[ealabels.CommunityRoleLabel.WithNamespace(namespace).String()]; ok {
-			delete(node.Labels, ealabels.CommunityRoleLabel.WithNamespace(namespace).String())
 		}
 
 		_, err = c.updateNode(context.TODO(), node, v1.UpdateOptions{})

--- a/pkg/system-controller/pkg/controller/update-communities_test.go
+++ b/pkg/system-controller/pkg/controller/update-communities_test.go
@@ -17,16 +17,14 @@ import (
 var resultObjectMeta = v1.ObjectMeta{
 	Name: "node-1",
 	Labels: map[string]string{
-		ealabels.CommunityRoleLabel.WithNamespace("").String(): "LEADER",
-		ealabels.CommunityLabel.WithNamespace("").String():     "community-1",
+		ealabels.CommunityLabel.WithNamespace("").String(): "community-1",
 	},
 }
 
 var notInCommunityMeta = v1.ObjectMeta{
 	Name: "node-4",
 	Labels: map[string]string{
-		ealabels.CommunityRoleLabel.WithNamespace("").String(): "MEMBER",
-		ealabels.CommunityLabel.WithNamespace("").String():     "community-2",
+		ealabels.CommunityLabel.WithNamespace("").String(): "community-2",
 	},
 }
 
@@ -65,8 +63,7 @@ func listNodeWithDifferentLabel(selector labels.Selector) (ret []*corev1.Node, e
 			ObjectMeta: v1.ObjectMeta{
 				Name: "node-1",
 				Labels: map[string]string{
-					ealabels.CommunityRoleLabel.WithNamespace("").String(): "MEMBER",
-					ealabels.CommunityLabel.WithNamespace("").String():     "community-2",
+					ealabels.CommunityLabel.WithNamespace("").String(): "community-2",
 				},
 			},
 		},
@@ -98,10 +95,8 @@ func TestUpdateCommunityNodes(t *testing.T) {
 					Name: "community-1",
 					Members: []slpaclient.Host{
 						{
-							Name: "node-1",
-							Labels: map[string]interface{}{
-								ealabels.CommunityRoleLabel.WithNamespace("").String(): "LEADER",
-							},
+							Name:   "node-1",
+							Labels: map[string]interface{}{},
 						},
 					},
 				},
@@ -122,10 +117,8 @@ func TestUpdateCommunityNodes(t *testing.T) {
 					Name: "community-1",
 					Members: []slpaclient.Host{
 						{
-							Name: "node-1",
-							Labels: map[string]interface{}{
-								ealabels.CommunityRoleLabel.WithNamespace("").String(): "LEADER",
-							},
+							Name:   "node-1",
+							Labels: map[string]interface{}{},
 						},
 					},
 				},
@@ -146,10 +139,8 @@ func TestUpdateCommunityNodes(t *testing.T) {
 					Name: "community-1",
 					Members: []slpaclient.Host{
 						{
-							Name: "node-1",
-							Labels: map[string]interface{}{
-								ealabels.CommunityRoleLabel.WithNamespace("").String(): "LEADER",
-							},
+							Name:   "node-1",
+							Labels: map[string]interface{}{},
 						},
 					},
 				},
@@ -170,10 +161,8 @@ func TestUpdateCommunityNodes(t *testing.T) {
 					Name: "community-1",
 					Members: []slpaclient.Host{
 						{
-							Name: "node-1",
-							Labels: map[string]interface{}{
-								ealabels.CommunityRoleLabel.WithNamespace("").String(): "LEADER",
-							},
+							Name:   "node-1",
+							Labels: map[string]interface{}{},
 						},
 					},
 				},

--- a/pkg/system-controller/pkg/e2e/system_controller_test.go
+++ b/pkg/system-controller/pkg/e2e/system_controller_test.go
@@ -2,11 +2,12 @@ package e2e_test
 
 import (
 	"context"
-	openfaasv1 "github.com/openfaas/faas-netes/pkg/apis/openfaas/v1"
-	"k8s.io/utils/pointer"
 	"strconv"
 	"testing"
 	"time"
+
+	openfaasv1 "github.com/openfaas/faas-netes/pkg/apis/openfaas/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/emirpasic/gods/sets/hashset"
 
@@ -58,7 +59,6 @@ var _ = Describe("System Controller", func() {
 		generatedCommunities := hashset.New()
 
 		ctx := context.Background()
-
 
 		It("Waits for nodes to become ready", func() {
 
@@ -130,18 +130,6 @@ var _ = Describe("System Controller", func() {
 
 				for _, community := range communities {
 					Expect(len(community)).To(BeNumerically("<=", cc.Spec.CommunitySize))
-
-					hasLeader := false
-
-					for _, node := range community {
-						if node.Labels[ealabels.CommunityRoleLabel.WithNamespace(namespace).String()] == ealabels.Leader.String() {
-							hasLeader = true
-						}
-					}
-
-					if !hasLeader {
-						return false
-					}
 				}
 				return true
 			}, 5*timeout, interval).Should(BeTrue())
@@ -276,7 +264,6 @@ var _ = Describe("System Controller", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				var communityLabelExists bool
-				var communityRoleLabelExists bool
 
 				for _, node := range nodes.Items {
 					labels := node.Labels
@@ -287,9 +274,8 @@ var _ = Describe("System Controller", func() {
 					}
 
 					_, communityLabelExists = node.Labels[ealabels.CommunityLabel.WithNamespace(cc.Namespace).String()]
-					_, communityRoleLabelExists = node.Labels[ealabels.CommunityRoleLabel.WithNamespace(cc.Namespace).String()]
 
-					if communityLabelExists || communityRoleLabelExists {
+					if communityLabelExists {
 						return false
 					}
 				}

--- a/pkg/system-controller/pkg/slpaclient/fakeclient.go
+++ b/pkg/system-controller/pkg/slpaclient/fakeclient.go
@@ -33,7 +33,6 @@ func (fc *FakeClient) Communities(req *RequestSLPA) (result []Community, err err
 	communityIndex := 0
 	for _, node := range req.Hosts {
 		node.Labels[ealabels.CommunityLabel.String()] = result[communityIndex].Name
-		node.Labels[ealabels.CommunityRoleLabel.String()] = ealabels.Member.String()
 		result[communityIndex].Members = append(result[communityIndex].Members, node)
 
 		if communityIndex < communities-1 {
@@ -41,10 +40,6 @@ func (fc *FakeClient) Communities(req *RequestSLPA) (result []Community, err err
 		} else {
 			communityIndex = 0
 		}
-	}
-
-	for _, community := range result {
-		community.Members[0].Labels[ealabels.CommunityRoleLabel.String()] = ealabels.Leader.String()
 	}
 
 	return result, err

--- a/pkg/system-controller/pkg/slpaclient/fakeclient_test.go
+++ b/pkg/system-controller/pkg/slpaclient/fakeclient_test.go
@@ -23,15 +23,13 @@ func TestFakeCommunities(t *testing.T) {
 						{
 							Name: "node-1",
 							Labels: map[string]interface{}{
-								ealabels.CommunityRoleLabel.String(): ealabels.Leader.String(),
-								ealabels.CommunityLabel.String():     "community-0",
+								ealabels.CommunityLabel.String(): "community-0",
 							},
 						},
 						{
 							Name: "node-3",
 							Labels: map[string]interface{}{
-								ealabels.CommunityRoleLabel.String(): ealabels.Member.String(),
-								ealabels.CommunityLabel.String():     "community-0",
+								ealabels.CommunityLabel.String(): "community-0",
 							},
 						},
 					},
@@ -42,8 +40,7 @@ func TestFakeCommunities(t *testing.T) {
 						{
 							Name: "node-2",
 							Labels: map[string]interface{}{
-								ealabels.CommunityRoleLabel.String(): ealabels.Leader.String(),
-								ealabels.CommunityLabel.String():     "community-1",
+								ealabels.CommunityLabel.String(): "community-1",
 							},
 						},
 					},


### PR DESCRIPTION
This PR removes the community role label, fixing the crashes due to a change in SLPA return type